### PR TITLE
I2C address to 0x15, default setting

### DIFF
--- a/BMA400.h
+++ b/BMA400.h
@@ -34,7 +34,7 @@
 #include <Wire.h>
 
 
-#define BMA400_ADDRESS                  0x14
+#define BMA400_ADDRESS                  0x15 // default setting
 
 #define BMA400_CHIPID                   0x00
 #define BMA400_ERR_REG                  0x02


### PR DESCRIPTION
Default I2C address of this board is 0x15, although it can be changed to 0x14. I2C address definition in library source should be default hardware setting.